### PR TITLE
rt72337: perl 5.12 gives "Use of uninitialized .."

### DIFF
--- a/lib/REST/Utils.pm
+++ b/lib/REST/Utils.pm
@@ -356,11 +356,12 @@ attempted, it will be ignored.
 sub request_method {
     my ($cgi) = @_;
 
-    my $real_method = uc $cgi->request_method() || q{};
+    my $real_method = uc( $cgi->request_method() || q{} );
     my $tunnel_method =
       uc(    $cgi->http('X-HTTP-Method-Override')
           || $cgi->url_param('_method')
-          || $cgi->param('_method') )
+          || $cgi->param('_method')
+          || q{} )
       || undef;
 
     return $real_method if !defined $tunnel_method;


### PR DESCRIPTION
https://rt.cpan.org/Public/Bug/Display.html?id=72337

Fix "Use of unitialized value in uc ..." warnings when running with
perl 5.12

Thanks for this excellent library :-)
